### PR TITLE
pin to trivy 0.35.0

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -60,7 +60,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"
-      - uses: "aquasecurity/trivy-action@0.9.0"
+      - uses: "aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1" # v0.35.0
         with:
           scan-type: "fs"
           ignore-unfixed: true


### PR DESCRIPTION
## Description

Pin to an uncompromised sha. We got lucky that this job didn't run within the window.

## References
https://socket.dev/blog/trivy-under-attack-again-github-actions-compromise